### PR TITLE
Fix MCP server validation error by making error_status required

### DIFF
--- a/packages/zod-types/src/mcp-servers.zod.ts
+++ b/packages/zod-types/src/mcp-servers.zod.ts
@@ -190,7 +190,7 @@ export const McpServerSchema = z.object({
   created_at: z.string(),
   bearerToken: z.string().nullable(),
   user_id: z.string().nullable(),
-  error_status: McpServerErrorStatusEnum.optional(),
+  error_status: McpServerErrorStatusEnum,
 });
 
 export const CreateMcpServerResponseSchema = z.object({


### PR DESCRIPTION
## Summary
- Fix "Error Loading MCP Servers" validation failure 
- Make error_status required in McpServerSchema to match database default

## Test plan
- [ ] Verify MCP servers page loads without validation errors
- [ ] Confirm existing functionality remains intact
- [ ] Check build succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)